### PR TITLE
fix: checking if cell is occupied in tic tac toe board

### DIFF
--- a/app/Http/Controllers/MoveController.php
+++ b/app/Http/Controllers/MoveController.php
@@ -19,6 +19,10 @@ class MoveController extends Controller
 
         $turn = $this->getBitCount($game->board) % 2;
 
+        if($game->board & (1 << ($request->index*2+$turn))) {
+            return response()->json(["error" => "Cell already occupied"]);
+        }
+
         $game->board |= 1 << ($request->index*2+$turn);
         
         // switch turn


### PR DESCRIPTION
This pull request includes an important change to the `MoveController.php` file to add validation for cell occupancy in the `move` function. This ensures that a move cannot be made on an already occupied cell.

Validation for cell occupancy:

* [`app/Http/Controllers/MoveController.php`](diffhunk://#diff-1852866d313218a88852b7c0bb0169a404ffa8f2fb7a2ae7a2ebe55103e2e001R22-R25): Added a check to verify if the cell is already occupied before making a move, and returns an error response if true.